### PR TITLE
Fix some minor bugs, and Python 3 compatibility

### DIFF
--- a/construct3/adapters.py
+++ b/construct3/adapters.py
@@ -1,6 +1,8 @@
 from construct3.packers import Adapter, noop, Raw, PackerError, _contextify, UnnamedPackerMixin, Sequence
 from construct3.lib import this
 from construct3.lib.containers import Container
+from construct3.lib.config import Config
+
 try:
     from io import BytesIO
 except ImportError:
@@ -136,10 +138,10 @@ class Tunnel(Adapter):
         Adapter.__init__(self, bottom)
         self.top = top
     def _decode(self, obj, context):
-        return self.top._unpack(BytesIO(obj), context)
+        return self.top._unpack(BytesIO(obj), context, Config())
     def _encode(self, obj, context):
         stream2 = BytesIO()
-        self.top._pack(obj, stream2, context)
+        self.top._pack(obj, stream2, context, Config())
         return stream2.getvalue()
 
 

--- a/construct3/lib/binutil.py
+++ b/construct3/lib/binutil.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     assert bits_to_num(num_to_bits(128, 8)) == 128 
     assert bits_to_num(num_to_bits(255, 8), signed = True) == -1
     assert bits_to_bytes(bytes_to_bits(six.b("ABC"))) == six.b("ABC")
-    print hexdump("hello world what is the up? how\t\r\n\x00\xff are we feeling today?!", 16)
+    print(hexdump("hello world what is the up? how\t\r\n\x00\xff are we feeling today?!", 16))
 
 
 

--- a/construct3/lib/containers.py
+++ b/construct3/lib/containers.py
@@ -1,5 +1,5 @@
 import itertools
-
+import six
 _counter = itertools.count()
 
 class Container(dict):
@@ -10,7 +10,7 @@ class Container(dict):
     def __setitem__(self, key, val):
         dict.__setitem__(self, key, val)
         if key not in self.__order__:
-            self.__order__[key] = _counter.next()
+            self.__order__[key] = six.next(_counter)
     def __delitem__(self, key):
         dict.__delitem__(self, key)
         del self.__order__[key]
@@ -26,7 +26,7 @@ class Container(dict):
     __setattr__ = __setitem__
     __delattr__ = __delitem__
     def __iter__(self):
-        items = self.__order__.items()
+        items = list(self.__order__.items())
         items.sort(key = lambda item: item[1])
         return (k for k, _ in items)
     def keys(self):


### PR DESCRIPTION
use six.integer_types since Python 3 doesn't have `long`
use sys.maxsize since sys.maxint doesn't exist in Python 3 (they are identical on most systems)... consider using something like itertools.count here
remove **slots** from Adapter, with **slots** python 3 forces objects to be immutable which was not desired (_encode/_decode cannot be modified). __slots__ is unlikely to have a significant performance impact since there won't be that many adapters.
add parens to print
in python3 `dict.keys()` returns a DictView iterator object not a list so it cannot be sorted in place. Hrm, this will copy the list on Python 2 though.

default None in Adapter should not overload subclasses _encode and _decode, check to see if _encode/_decode exist before overwriting them.

One style change `x if x else default` changed to `x or default` which is more idiomatic
